### PR TITLE
add Auth0 Domain to CSP

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -3,7 +3,13 @@ import cors from "cors";
 import path from "path";
 import helmet from "helmet";
 
-import { API_PORT, FRONTEND_URL, APPLICATION_NAME, VUE_APP } from "./config";
+import {
+  API_PORT,
+  FRONTEND_URL,
+  APPLICATION_NAME,
+  AUTH0_DOMAIN,
+  VUE_APP,
+} from "./config";
 // import { doHealthCheck } from "./utils/healthCheck";
 // import { userRouter, authoritiesRouter, employeeRouter, departmentRouter, formARouter } from "./routes";
 
@@ -32,7 +38,7 @@ app.use(express.urlencoded({ extended: true })); // for parsing application/x-ww
 app.use(
   helmet.contentSecurityPolicy({
     directives: {
-      "default-src": ["'self'"],
+      "default-src": ["'self'", AUTH0_DOMAIN],
       "base-uri": ["'self'"],
       "block-all-mixed-content": [],
       "font-src": ["'self'", "https:", "data:"],


### PR DESCRIPTION
The content security policy enforced by helmet.js block the silent authentication call to the auth provider.  This PR sets the AUTH domain as an allowed location. 